### PR TITLE
Upload

### DIFF
--- a/examples/sample.ts
+++ b/examples/sample.ts
@@ -1,4 +1,4 @@
-import WebServer from '../src/WebServer';
+import HttpServer from '../src/servers/HttpServer';
 import ServeFile from '../src/middleware/ServeFile';
 import ServeDirectory from '../src/middleware/ServeDirectory';
 import route, { IncomingRoute } from '../src/handlers/route';
@@ -8,8 +8,14 @@ import Forwarder from '../src/middleware/Forwarder';
 import { noCache } from '../src/middleware/SetHeaders';
 import { setLogLevel } from '../src/log';
 import { ServerResponse } from 'http';
+import incomingFiles from '../src/transforms/incomingFiles';
+import WebApplication from '../src/middleware/WebApplication';
+import SaveFiles from '../src/middleware/SaveFiles';
 
-const server = new WebServer();
+const server = new HttpServer({
+	port: 7777
+}, new WebApplication());
+
 const notFound = new NotFound();
 
 // Set logging to debug for more verbose output
@@ -38,8 +44,11 @@ server.app.middleware.add([
 		// If none of the above handlers match; return a 404
 		notFound
 	]),
+	route('/upload').transform(incomingFiles).wrap(new SaveFiles('_uploads', {
+		createUploadDirectory: true
+	})),
 	route('/echo/:words').wrap(echoRoute)
 ]);
 
 server.start();
-console.log(`started server on ${ server.config.port }`);
+console.log(`started server on ${ server.port }`);

--- a/package.json
+++ b/package.json
@@ -23,12 +23,16 @@
     "example-basic": "ts-node ./examples/basic"
   },
   "dependencies": {
+    "@types/busboy": "^0.2.3",
+    "@types/mkdirp": "^0.5.0",
     "@types/node": "0.0.2",
     "@types/pem": "^1.9.2",
     "@types/winston": "^2.2.0",
+    "busboy": "^0.2.14",
     "commander": "^2.9.0",
     "findup": "^0.1.5",
     "http-proxy": "^1.16.2",
+    "mkdirp": "^0.5.1",
     "path-to-regexp": "^1.7.0",
     "pem": "^1.9.7",
     "send": "^0.14.1",

--- a/src/handlers/transform.ts
+++ b/src/handlers/transform.ts
@@ -1,10 +1,6 @@
-/*
- * Functions used to transform request data
- */
-import { Handler, HandlerResponse, HandlerFunction } from './Handler';
+import { Handler, HandlerFunction, HandlerResponse } from './Handler';
 import { IncomingMessage, ServerResponse } from 'http';
-import { parse as parseUrl, format as formatUrl } from 'url';
-import { overrideWrapper, descriptorWrapper } from '../util/proxies';
+import { overrideWrapper } from '../util/proxies';
 
 export interface Transform {
 	(request: IncomingMessage): IncomingMessage;
@@ -35,32 +31,4 @@ export function proxy(handler: Handler, transformFunc: Transform): Handler {
 	return overrideWrapper(handler, {
 		handle: transform(handler.handle.bind(handler), transformFunc)
 	});
-}
-
-/**
- * A helper transform used to change the pathname of the url
- *
- * @param match text to match
- * @param replace text to replace
- * @return a function that transforms an IncomingMessage
- */
-export function relativeUrl(match: string, replace: string = ''): Transform {
-	return function (request: IncomingMessage) {
-		return descriptorWrapper(request, {
-			originalUrl: {
-				get() {
-					return request.url;
-				}
-			},
-			url: {
-				get() {
-					const requestUrl = parseUrl(request.url);
-					if (requestUrl.path.indexOf(match) === 0) {
-						requestUrl.path = requestUrl.pathname = replace + requestUrl.path.substring(match.length) || '/';
-					}
-					return formatUrl(requestUrl);
-				}
-			}
-		});
-	};
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,8 @@ import * as proxies from './util/proxies';
 import WebApplication from './middleware/WebApplication';
 import HttpsServer from './servers/HttpsServer';
 import HttpServer from './servers/HttpServer';
+import incomingFiles from './transforms/incomingFiles';
+import relativeUrl from './transforms/relativeUrl';
 
 // This index is used to support a node.js require without worrying about `default` values
 
@@ -34,6 +36,11 @@ export const middleware = {
 export const servers = {
 	HttpServer,
 	HttpsServer
+};
+
+export const transforms = {
+	incomingFiles,
+	relativeUrl
 };
 
 export const util = {

--- a/src/middleware/SaveFiles.ts
+++ b/src/middleware/SaveFiles.ts
@@ -1,0 +1,110 @@
+import '../polyfills';
+import { Handler, HandlerResponse } from '../handlers/Handler';
+import { IncomingMessage, ServerResponse } from 'http';
+import { hasIncomingFiles } from '../transforms/incomingFiles';
+import * as path from 'path';
+import { log } from '../log';
+import mkdirp = require('mkdirp');
+import * as fs from 'fs';
+
+function htmlTemplate(body: string) {
+	return `
+<html>
+<head>
+	<title>Upload File</title>
+</head>
+<body>
+	${ body }
+</form>
+</body>
+</html>
+`;
+}
+
+function defaultUploadForm() {
+	return htmlTemplate(`
+<form method="post" enctype="multipart/form-data">
+<p>
+	<input type="file" name="uploadedFiles" multiple>
+</p>
+<p>
+	<input type="submit" value="Upload file">
+</p>
+	`);
+}
+
+function defaultUploadResponse(files: string[], failed: string[]) {
+	if (files.length || failed.length) {
+		const uploaded = files.map(file => `<p>Saved: ${ file }</p>`).join('\n');
+		const notUploaded = failed.map(file => `<p>Failed: ${ file }</p>`).join('\n');
+		return htmlTemplate(uploaded + notUploaded);
+	}
+	else {
+		return htmlTemplate('No files uploaded');
+	}
+}
+
+export interface Options {
+	allowOverwrite?: boolean;
+	createUploadDirectory?: boolean;
+	uploadForm?: UploadFile['uploadForm'];
+	uploadResponse?: UploadFile['uploadResponse'];
+}
+
+export default class UploadFile implements Handler {
+	readonly allowOverwrite: boolean;
+
+	readonly createUploadDirectory: boolean;
+
+	readonly directory: string;
+
+	readonly uploadForm: () => string;
+
+	readonly uploadResponse: (files: string[], failed: string[]) => string;
+
+	constructor(directory: string, options: Options = {}) {
+		this.directory = directory;
+		this.allowOverwrite = options.allowOverwrite || false;
+		this.createUploadDirectory = options.createUploadDirectory || false;
+		this.uploadForm = options.uploadForm || defaultUploadForm;
+		this.uploadResponse = options.uploadResponse || defaultUploadResponse;
+	}
+
+	async handle(request: IncomingMessage, response: ServerResponse): Promise<HandlerResponse> {
+		if (this.createUploadDirectory) {
+			await new Promise((resolve, reject) => {
+				mkdirp(path.resolve(this.directory), (err) => {
+					err ? reject(err) : resolve();
+				});
+			});
+		}
+
+		if (request.method === 'POST') {
+			let files: string[] = [];
+			let failed: string[] = [];
+
+			if (hasIncomingFiles(request)) {
+				for await (let { file, filename } of request.files()) {
+					const absoluteFilename = path.resolve(path.join(this.directory, path.basename(filename)));
+
+					if (this.allowOverwrite || !fs.existsSync(absoluteFilename)) {
+						file.pipe(fs.createWriteStream(absoluteFilename));
+						log.info(`Saved ${ filename } to ${ absoluteFilename }`);
+						files.push(filename);
+					}
+					else {
+						file.resume();
+						log.warn(`File already exists! ${ absoluteFilename }`);
+						failed.push(filename);
+					}
+				}
+			}
+			response.write(this.uploadResponse(files, failed));
+			response.end();
+		}
+		else if (request.method === 'GET') {
+			response.write(this.uploadForm());
+			response.end();
+		}
+	}
+}

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -1,0 +1,3 @@
+if (!Symbol.asyncIterator) {
+	(<any> Symbol).asyncIterator = Symbol();
+}

--- a/src/transforms/incomingFiles.ts
+++ b/src/transforms/incomingFiles.ts
@@ -1,0 +1,75 @@
+import { IncomingMessage } from 'http';
+import { descriptorWrapper } from '../util/proxies';
+import * as BusBoy from 'busboy';
+import BufferedResponse from '../util/BufferedResponse';
+import { Transform } from '../handlers/transform';
+import '../polyfills';
+import { log } from '../log';
+
+export interface IncomingFile {
+	fieldName: string;
+	file: NodeJS.ReadableStream;
+	filename: string;
+	encoding: string;
+	mimeType: string;
+}
+
+function setupBuffer(request: IncomingMessage): BufferedResponse<IncomingFile> {
+	const busboy = new BusBoy({
+		headers: request.headers
+	});
+
+	const buffer: BufferedResponse<IncomingFile> = new BufferedResponse<IncomingFile>();
+
+	busboy.on('file', (fieldName, file, filename, encoding, mimeType) => {
+		log.info(`Uploaded file: ${ filename }, encoding ${ encoding }, mimetype: ${ mimeType }`);
+		buffer.add({
+			fieldName,
+			file,
+			filename,
+			encoding,
+			mimeType
+		});
+	});
+
+	busboy.on('finish', function() {
+		buffer.close();
+	});
+
+	request.pipe(busboy);
+
+	return buffer;
+}
+
+/**
+ * Creates a files property on the incoming request with any files being uploaded
+ */
+const incomingFiles: Transform = function (request: IncomingMessage): IncomingMessage  {
+	let buffer: BufferedResponse<IncomingFile>;
+
+	if (request.method === 'POST') {
+		return descriptorWrapper<IncomingMessage>(request, {
+			files: {
+				get() {
+					if (!buffer) {
+						buffer = setupBuffer(request);
+					}
+					return buffer[Symbol.asyncIterator].bind(buffer);
+				},
+				configurable: true
+			}
+		});
+	}
+
+	return request;
+};
+
+export interface IncomingFiles extends IncomingMessage {
+	files(): AsyncIterableIterator<IncomingFile>;
+}
+
+export function hasIncomingFiles(request: any): request is IncomingFiles {
+	return !!(request && request.hasOwnProperty('files'));
+}
+
+export default incomingFiles;

--- a/src/transforms/relativeUrl.ts
+++ b/src/transforms/relativeUrl.ts
@@ -1,0 +1,32 @@
+import { Transform } from '../handlers/transform';
+import { IncomingMessage } from 'http';
+import { descriptorWrapper } from '../util/proxies';
+import { parse as parseUrl, format as formatUrl } from 'url';
+
+/**
+ * A helper transform used to change the pathname of the url
+ *
+ * @param match text to match
+ * @param replace text to replace
+ * @return a function that transforms an IncomingMessage
+ */
+export default function relativeUrl(match: string, replace: string = ''): Transform {
+	return function (request: IncomingMessage) {
+		return descriptorWrapper(request, {
+			originalUrl: {
+				get() {
+					return request.url;
+				}
+			},
+			url: {
+				get() {
+					const requestUrl = parseUrl(request.url);
+					if (requestUrl.path.indexOf(match) === 0) {
+						requestUrl.path = requestUrl.pathname = replace + requestUrl.path.substring(match.length) || '/';
+					}
+					return formatUrl(requestUrl);
+				}
+			}
+		});
+	};
+}

--- a/src/util/BufferedResponse.ts
+++ b/src/util/BufferedResponse.ts
@@ -1,0 +1,82 @@
+import '../polyfills';
+
+const DONE = Symbol();
+
+type BufferData<T> = Symbol | T;
+
+interface Resolve<T> {
+	(result?: BufferData<T> | PromiseLike<BufferData<T>>): void;
+}
+
+interface Notifier<T> {
+	offset: number;
+	resolve: Resolve<T>;
+}
+
+/**
+ * Provide a stream of responses from a producer
+ */
+export default class BufferedResponse<T> {
+	private data: BufferData<T>[] = [];
+
+	private done = false;
+
+	private notifiers: Notifier<T>[] = [];
+
+	add(item: T) {
+		if (!this.done) {
+			this.data.push(item);
+			this.notify();
+		}
+	}
+
+	close() {
+		if (!this.done) {
+			this.done = true;
+			this.data.push(DONE);
+			this.notify();
+		}
+	}
+
+	async *[Symbol.asyncIterator](): AsyncIterableIterator<T> {
+		let i = 0;
+		let value: BufferData<T> = await this.wait(i++);
+
+		while (this.isValue(value)) {
+			yield value;
+			value = await this.wait(i++);
+		}
+	}
+
+	private isValue(value: any): value is T {
+		return value !== DONE;
+	}
+
+	private notify() {
+		for (let i = this.notifiers.length - 1; i >= 0; i--) {
+			const notifier = this.notifiers[i];
+
+			if (this.data.length > notifier.offset) {
+				notifier.resolve(this.data[notifier.offset]);
+				this.notifiers.slice(i, 1);
+			}
+			else if (this.done) {
+				notifier.resolve(DONE);
+				this.notifiers.slice(i, 1);
+			}
+		}
+	}
+
+	private wait(i: number): Promise<BufferData<T>> {
+		if (i < this.data.length) {
+			return Promise.resolve(this.data[i]);
+		}
+
+		return new Promise<BufferData<T>>((resolve) => {
+			this.notifiers.push({
+				offset: i,
+				resolve
+			});
+		});
+	}
+}

--- a/src/util/proxies.ts
+++ b/src/util/proxies.ts
@@ -43,8 +43,8 @@ export function overrideWrapper(target: Object, values: { [ key: string ]: any }
  * @param descriptors a map of descriptors
  * @return a Proxied object where descriptors are overridden by the property descriptor map
  */
-export function descriptorWrapper(target: Object, descriptors: PropertyDescriptorMap = {}) {
-	return new Proxy(target, {
+export function descriptorWrapper<T extends object = object>(target: T, descriptors: PropertyDescriptorMap = {}): T {
+	return new Proxy<T>(target, {
 		get(target: any, property: PropertyKey): any {
 			if (isGetPropertyDescriptor(descriptors[property])) {
 				return descriptors[property].get();
@@ -61,7 +61,7 @@ export function descriptorWrapper(target: Object, descriptors: PropertyDescripto
 				return descriptors[property];
 			}
 
-			return target.getOwnPropertyDescriptor(property);
+			return Object.getOwnPropertyDescriptor(target, property);
 		},
 
 		set(target: any, property: PropertyKey, value: any): boolean {

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -7,7 +7,8 @@
 			"es2015",
 			"dom",
 			"es2015.symbol",
-			"es2015.proxy"
+			"es2015.proxy",
+			"esnext.asynciterable"
 		],
 		"module": "umd",
 		"moduleResolution": "node",

--- a/tests/unit/all.ts
+++ b/tests/unit/all.ts
@@ -10,3 +10,4 @@ import './middleware/ServeFile';
 import './middleware/WebApplication';
 import './servers/HttpServer';
 import './servers/HttpsServer';
+import './util/BufferedResponse';

--- a/tests/unit/util/BufferedResponse.ts
+++ b/tests/unit/util/BufferedResponse.ts
@@ -1,0 +1,56 @@
+import * as registerSuite from 'intern!object';
+import * as assert from 'intern/chai!assert';
+import BufferedResponse from 'src/util/BufferedResponse';
+
+registerSuite({
+	name: 'src/util/BufferedResponse',
+
+	add: {
+		async 'add an item'() {
+			const expected = Symbol();
+			const buffer = new BufferedResponse<Symbol>();
+
+			buffer.add(expected);
+
+			const iterator = buffer[Symbol.asyncIterator]();
+
+			assert.strictEqual((await iterator.next()).value, expected);
+		},
+
+		async 'response is done; no item is added'() {
+			const buffer = new BufferedResponse<Symbol>();
+
+			buffer.close();
+			buffer.add(Symbol());
+
+			for await (let _item of buffer) {
+				assert.fail();
+			}
+		}
+	},
+
+	close: {
+		async 'close a stream'() {
+			const buffer = new BufferedResponse<Symbol>();
+
+			buffer.close();
+
+			for await (let _item of buffer) {
+				assert.fail();
+			}
+		}
+	},
+
+	async 'async iterator'() {
+		const buffer = new BufferedResponse<Symbol>();
+		const expected = [ Symbol(), Symbol(), Symbol() ];
+
+		expected.forEach(item => buffer.add(item));
+		buffer.close();
+
+		for await (let item of buffer) {
+			assert.strictEqual(item, expected.shift());
+		}
+		assert.lengthOf(expected, 0);
+	}
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,10 +4,12 @@
 		"allowSyntheticDefaultImports": true,
 		"baseUrl": ".",
 		"declaration": true,
+		"downlevelIteration": true,
 		"experimentalDecorators": true,
 		"lib": [
 			"es2015",
-			"es2017.object"
+			"es2017.object",
+			"esnext.asynciterable"
 		],
 		"module": "commonjs",
 		"moduleResolution": "node",


### PR DESCRIPTION
* add `incomingFiles` transform that provides an async iterator for incoming file streams to the `IncomingMessage`
* add `SaveFiles` middleware that leverages files for POST messages and an upload form for GET requests

The `SaveFiles` implementation is just a basic example of how to use the `incomingFiles` transform. I assume that for all but the most basic of uses, people will want to customize the save file endpoint and perform more robust file handling.