### PR TITLE
Updated grunt task

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@types/sinon": "^1.16.36",
     "codecov": "^2.3.0",
     "grunt": "^1.0.1",
+    "grunt-cli": "^1.2.0",
     "grunt-contrib-clean": "^1.1.0",
     "grunt-contrib-copy": "^1.0.0",
     "grunt-shell": "^2.1.0",

--- a/src/servers/BasicServer.ts
+++ b/src/servers/BasicServer.ts
@@ -62,7 +62,7 @@ export abstract class BasicServer<T extends Handler = WebApplication> extends Ev
 	}
 
 	protected onSignal(signal: string) {
-		log.info(`received ${ signal } signal. Stopping server.`);
+		log.info(`received ${ signal } signal. Stopping server on ${ this.port }.`);
 		this.stop();
 	}
 }

--- a/src/tasks/webserv.ts
+++ b/src/tasks/webserv.ts
@@ -2,6 +2,9 @@ import createServer, { Config } from '../commands/createServer';
 import IMultiTask = grunt.task.IMultiTask;
 import { log } from '../log';
 import { inspect } from 'util';
+import { BasicServer, ServerState } from '../servers/BasicServer';
+
+const servers: BasicServer[] = [];
 
 /**
  * A Grunt MultiTask that will start a server
@@ -10,14 +13,46 @@ import { inspect } from 'util';
  */
 export = function (grunt: IGrunt) {
 	grunt.registerMultiTask('webserv', function (this: IMultiTask<Config>) {
+		function onFail(error: Error) {
+			grunt.fail.warn(`Failed to start server ${ error.message }`);
+		}
+
 		const done = this.async();
+		// If true then wait until the server stops to resolve the task; otherwise close the server on process exit
+		const shouldWait = (<any> this.data).wait !== false;
+
 		createServer(this.data)
 			.then((server) => {
-				server.on('stopped', done);
 				log.debug(`Grunt configuration: ${ inspect(this.data, { depth: 3 }) }`);
-				server.start().then(function (state) {
-					log.info(`Server started on port ${ server.port }`);
-				}, done);
-			}, done);
+				servers.push(server);
+
+				if (shouldWait) {
+					server.on('StateChange', (state: string) => {
+						if (state === ServerState.STOPPED) {
+							done();
+						}
+					});
+				}
+
+				if (server.state !== ServerState.LISTENING) {
+					server.start().then(function () {
+						log.info(`Server started on port ${ server.port }`);
+						grunt.event.emit('startedServer', server);
+						!shouldWait && done();
+					}, onFail);
+				}
+				else {
+					!shouldWait && done();
+				}
+			}, onFail);
+	});
+
+	grunt.registerTask('stopServers', function (this: IMultiTask<Config>) {
+		const done = this.async();
+
+		Promise.all(servers.map(server => {
+			grunt.log.write(`Stopping server on port ${ server.port }`);
+			return server.stop();
+		})).then(done, done);
 	});
 };

--- a/support/grunt/config.ts
+++ b/support/grunt/config.ts
@@ -93,6 +93,11 @@ export const tslint = {
 };
 
 export const webserv = {
+	nonWaiting: {
+		port: '8890',
+		directory: '.',
+		wait: false
+	},
 	server: {
 		port: '8889',
 			directory: '.',

--- a/tests/unit/tasks/webserv.ts
+++ b/tests/unit/tasks/webserv.ts
@@ -1,26 +1,42 @@
+import { assert } from 'chai';
 import registerSuite from 'intern/lib/interfaces/object';
 import * as webserv from 'src/tasks/webserv';
-import * as sinon from 'sinon';
+import { SinonStub, spy, stub } from 'sinon';
 
 let taskMock: any;
+let grunt: IGrunt;
 
 registerSuite('src/tasks/webserv', {
 	beforeEach() {
+		grunt = <any> {
+			event: {
+				emit: stub()
+			},
+			fail: {
+				warn: stub()
+			},
+			log: {
+				write: stub()
+			},
+			registerMultiTask: stub(),
+			registerTask: stub()
+		};
 		taskMock = {
 			data: { },
-			done: sinon.spy(function () {
-				return sinon.stub();
+			done: spy(function () {
+				return stub();
 			})
 		};
+		webserv.call(taskMock, grunt);
 	},
 
 	tests: {
 		construction: {
 			'default'() {
-				const grunt = {
-					registerMultiTask: sinon.stub()
-				};
-				webserv.call(taskMock, grunt);
+				assert.isTrue((<SinonStub> grunt.registerMultiTask).calledOnce);
+				assert.isTrue((<SinonStub> grunt.registerTask).calledOnce);
+				assert.strictEqual((<SinonStub> grunt.registerMultiTask).firstCall.args[0], 'webserv');
+				assert.strictEqual((<SinonStub> grunt.registerTask).firstCall.args[0], 'stopServers');
 			}
 		}
 	}


### PR DESCRIPTION
Cleans up the webserv grunt task

* adds a `wait` parameter to the grunt task. If `wait` is set to true (or undefined) then the webserv task will not exit until the server is stopped. If `wait` is false then the webserv task will exit as soon as the server is started
* Adds a `startedServer` event that is emitted by grunt w/ the `server` payload. This allows people to extend how grunt deals with the server (hopefully without needing complicated compound tasks)
* Adds a `stopServers` grunt task that will stop all servers started by the `webserv` task. This is not a solution to stopping servers under failure conditions. Unfortunately grunt is really lacking for a `finally` or `teardown` phase 👎 .