### PR TITLE
Fixes files served with spaces in name

### DIFF
--- a/src/core/middleware/serve.ts
+++ b/src/core/middleware/serve.ts
@@ -16,7 +16,8 @@ export interface ServeProperties {
 }
 
 async function getPath(basePath: string, url: UrlWithStringQuery, extensions: string[] = []) {
-	const target = join(basePath, url.pathname);
+	const target = join(basePath, decodeURI(url.pathname));
+	console.log(target);
 
 	if (await checkAccess(target)) {
 		return target;

--- a/src/core/transforms/directory.transform.ts
+++ b/src/core/transforms/directory.transform.ts
@@ -26,7 +26,7 @@ export const directoryTransform: Transform = (result, request, response) => {
 		.map((file) => {
 			const relative = slash(file);
 			const url = slash(join(baseUrl, file));
-			return `<a href="${url}">${relative}</a>`;
+			return `<a href="${encodeURI(url)}">${relative}</a>`;
 		})
 		.join('<br>');
 	response.write(htmlTemplate('Directory listing', fileLinks));

--- a/tests/integration/_assets/sample1/child/file with a space.txt
+++ b/tests/integration/_assets/sample1/child/file with a space.txt
@@ -1,0 +1,1 @@
+file with a space

--- a/tests/integration/serve.test.ts
+++ b/tests/integration/serve.test.ts
@@ -53,7 +53,13 @@ describe('serve tests', () => {
 
 	it('displays a directory listing', async () => {
 		const result = await fetch('http://localhost:3001/child/');
-		const expected = `${CR}\t\t<html>${CR}\t\t<head>${CR}\t\t\t<title>Directory listing</title>${CR}\t\t</head>${CR}\t\t<body>${CR}\t\t\t<a href="/child/1.txt">1.txt</a><br><a href="/child/2.txt">2.txt</a>${CR}\t\t</form>${CR}\t\t</body>${CR}\t\t</html>${CR}\t\t`;
+		const expected =
+			`${CR}\t\t<html>${CR}\t\t<head>${CR}\t\t\t<title>Directory listing</title>${CR}\t\t</head>${CR}\t\t` +
+			`<body>${CR}\t\t\t<a href="/child/1.txt">1.txt</a><br>` +
+			`<a href="/child/2.txt">2.txt</a><br>` +
+			`<a href="/child/file%20with%20a%20space.txt">file with a space.txt</a>${CR}` +
+			`\t\t</form>${CR}\t\t</body>` +
+			`${CR}\t\t</html>${CR}\t\t`;
 
 		assert.strictEqual(result.status, 200);
 		assert.strictEqual(await result.text(), expected);
@@ -85,5 +91,12 @@ describe('serve tests', () => {
 
 		assert.strictEqual(result.status, 200);
 		assert.strictEqual(await result.text(), `console.log('Hello world');${EOL}`);
+	});
+
+	it('handles url encoded file with a space', async () => {
+		const result = await fetch('http://localhost:3001/child/file%20with%20a%20space.txt');
+
+		assert.strictEqual(result.status, 200);
+		assert.strictEqual(await result.text(), `file with a space${CR}`);
 	});
 });


### PR DESCRIPTION
When `serve` or `directoryTransform` were used `webserv` was not properly converting between url encoded path representations.