### PR TITLE
Add realtime upgrade w/ connection tracking

### DIFF
--- a/src/_support/bdd.ts
+++ b/src/_support/bdd.ts
@@ -1,0 +1,26 @@
+import { resolve, relative as relativePath } from 'path';
+import { describe } from 'intern/lib/interfaces/bdd';
+
+const SPEC_TEST_EXT_LEN = '.spec.ts'.length;
+
+function relative(path: string) {
+	const base = resolve(__dirname, '..');
+	return relativePath(base, path);
+}
+
+function trimSpec(path: string) {
+	if (path.indexOf('.spec') === path.length - SPEC_TEST_EXT_LEN) {
+		return path.slice(0, path.indexOf('.spec')) + path.slice(-3);
+	}
+	return path;
+}
+
+/**
+ * Automatically generates the module under test's filename
+ *
+ * @param path the __filename from the module
+ * @param cb a callback for the describe method
+ */
+export function describeSuite(path: string, cb: () => void) {
+	describe(trimSpec(relative(path)), cb);
+}

--- a/src/_support/mocks/mockLog.ts
+++ b/src/_support/mocks/mockLog.ts
@@ -1,0 +1,22 @@
+import * as sinon from 'sinon';
+
+export function mockLog(sandbox = sinon) {
+	return {
+		error: sandbox.stub(),
+		warn: sandbox.stub(),
+		help: sandbox.stub(),
+		data: sandbox.stub(),
+		info: sandbox.stub(),
+		debug: sandbox.stub(),
+		prompt: sandbox.stub(),
+		verbose: sandbox.stub(),
+		input: sandbox.stub(),
+		silly: sandbox.stub(),
+
+		emerg: sandbox.stub(),
+		alert: sandbox.stub(),
+		crit: sandbox.stub(),
+		warning: sandbox.stub(),
+		notice: sandbox.stub()
+	};
+}

--- a/src/core/interface.ts
+++ b/src/core/interface.ts
@@ -14,6 +14,8 @@ export type ProcessFactory<T extends object> = (options: T) => Process;
 
 export type Guard = (request: IncomingMessage) => boolean;
 
+export type AsyncGuard = (request: IncomingMessage) => boolean | Promise<boolean>;
+
 export type GuardFactory<T extends object> = (options: T) => Guard;
 
 export type MiddlewareResult = object | string | void;
@@ -74,6 +76,6 @@ export interface Upgrade {
 }
 
 export interface UpgradeDescriptor {
-	guards?: Guard[];
+	guards?: AsyncGuard[];
 	upgrade: UpgradeMiddleware | Array<Upgrade | UpgradeDescriptor>;
 }

--- a/src/core/services/action.service.spec.ts
+++ b/src/core/services/action.service.spec.ts
@@ -1,0 +1,167 @@
+/// <reference types="intern" />
+import { assert } from 'chai';
+import { before, describe, it } from 'intern/lib/interfaces/bdd';
+
+import { describeSuite } from '../../_support/bdd';
+import { setupMocks, setupSinon } from '../../_support/mocks';
+import { sendError, sendResponse, ActionServiceProperties } from './action.service';
+
+describeSuite(__filename, () => {
+	const sinon = setupSinon();
+	const realtimeUpgradeMock = sinon.stub().returns({});
+	let actionService: typeof import('./action.service').actionService;
+
+	setupMocks({
+		'../upgrades/realtime.upgrade': {
+			realtimeUpgrade: realtimeUpgradeMock
+		}
+	});
+
+	before(() => {
+		actionService = require('./action.service').actionService;
+	});
+
+	function createMockConnection() {
+		return {
+			client: {
+				send: sinon.stub()
+			}
+		} as any;
+	}
+
+	describe('sendError', () => {
+		it('sends an error', () => {
+			const con = createMockConnection();
+			const action = {
+				type: 'test',
+				payload: {
+					data: 'payload'
+				}
+			};
+			const payload = {
+				message: 'message'
+			};
+			const expected = {
+				type: 'test-error',
+				payload: {
+					...payload,
+					source: action
+				}
+			};
+			sendError(con, action, payload);
+			assert.strictEqual(con.client.send.callCount, 1);
+			assert.strictEqual(con.client.send.lastCall.args[0], JSON.stringify(expected));
+		});
+	});
+
+	describe('sendResponse', () => {
+		it('sends a serialized response', () => {
+			const con = createMockConnection();
+			const action = {
+				type: 'test',
+				payload: {}
+			};
+			sendResponse(con, action);
+			assert.strictEqual(con.client.send.callCount, 1);
+			assert.strictEqual(con.client.send.lastCall.args[0], JSON.stringify(action));
+		});
+
+		it('sends a response to all connections', () => {
+			const connections = [createMockConnection(), createMockConnection()];
+			const action = {
+				type: 'test',
+				payload: {}
+			};
+			sendResponse(connections, action);
+			for (let con of connections) {
+				assert.strictEqual(con.client.send.callCount, 1);
+				assert.strictEqual(con.client.send.lastCall.args[0], JSON.stringify(action));
+			}
+		});
+	});
+
+	describe('actionService', () => {
+		it('creates a service', () => {
+			const service = actionService({
+				handlers: []
+			});
+
+			assert.isDefined(service.upgrade.upgrade);
+		});
+
+		describe('onMessage', () => {
+			const methods = {};
+			const action = { type: 'test', payload: {} };
+			const con = createMockConnection();
+
+			function setup(props: ActionServiceProperties) {
+				actionService(props);
+
+				assert.strictEqual(realtimeUpgradeMock.callCount, 1);
+				const { onMessage } = realtimeUpgradeMock.lastCall.args[0];
+				return onMessage;
+			}
+
+			it('deserializes strings', () => {
+				const defaultHandler = sinon.stub();
+				const onMessage = setup({
+					handlers: [],
+					defaultHandler
+				});
+
+				onMessage(JSON.stringify(action), con, methods);
+
+				assert.strictEqual(defaultHandler.callCount, 1);
+				assert.deepEqual(defaultHandler.lastCall.args, [action, con, methods]);
+			});
+
+			it('ignores data that is not an action', () => {
+				const defaultHandler = sinon.stub();
+				const onMessage = setup({
+					handlers: [],
+					defaultHandler
+				});
+
+				onMessage('"i am not an action"', con, methods);
+
+				assert.strictEqual(defaultHandler.callCount, 0);
+			});
+
+			it('maps an action to a handler', () => {
+				const defaultHandler = sinon.stub();
+				const handler = sinon.stub();
+				const onMessage = setup({
+					handlers: [
+						{
+							type: action.type,
+							handler
+						}
+					],
+					defaultHandler
+				});
+
+				onMessage(JSON.stringify(action), con, methods);
+
+				assert.strictEqual(defaultHandler.callCount, 0);
+				assert.strictEqual(handler.callCount, 1);
+				assert.deepEqual(handler.lastCall.args, [action, con, methods]);
+			});
+
+			it('will ignore an action if there is no handler', () => {
+				const handler = sinon.stub();
+				const onMessage = setup({
+					handlers: [
+						{
+							type: 'not a matching type',
+							handler
+						}
+					]
+				});
+
+				onMessage(JSON.stringify(action), con, methods);
+
+				assert.strictEqual(handler.callCount, 0);
+			});
+		});
+	});
+});

--- a/src/core/services/action.service.ts
+++ b/src/core/services/action.service.ts
@@ -1,0 +1,93 @@
+import {
+	realtimeUpgrade,
+	Connection,
+	ConnectionMethods,
+	RealtimeUpgradeProperties
+} from '../upgrades/realtime.upgrade';
+import { Service } from '../app';
+
+export interface Action<T = any> {
+	type: string;
+	payload: T;
+}
+
+export type ActionMiddleware<T extends Action = Action> = (
+	data: T,
+	con: Connection,
+	methods: ConnectionMethods
+) => void | Promise<void>;
+
+export interface ActionHandlerDefinition {
+	type: string;
+	handler: ActionMiddleware<any>;
+}
+
+export interface ActionServiceProperties extends Omit<RealtimeUpgradeProperties, 'onMessage'> {
+	handlers: ActionHandlerDefinition[];
+	defaultHandler?: ActionMiddleware;
+}
+
+interface ErrorPayload {
+	message: string;
+}
+
+function isAction(value: any): value is Action {
+	return value && typeof value === 'object' && typeof value.type === 'string';
+}
+
+/**
+ * Helper function to send an error response to an action request
+ */
+export function sendError<T extends object, U extends any>(
+	con: Connection | Connection[],
+	source: Action<T>,
+	payload: ErrorPayload & U
+) {
+	sendResponse(con, {
+		type: `${source.type}-error`,
+		payload: {
+			...payload,
+			source
+		}
+	});
+}
+
+/**
+ * Helper function to send a serialized action to a connection
+ */
+export function sendResponse<T extends object>(con: Connection | Connection[], action: Action<T>) {
+	const data = JSON.stringify(action);
+	if (Array.isArray(con)) {
+		for (let connection of con) {
+			connection.client.send(data);
+		}
+	} else {
+		con.client.send(data);
+	}
+}
+
+/**
+ * This is a realtime message-passing service using Websockets built on top of realtime.upgrade.
+ */
+export function actionService({ handlers, defaultHandler, ...rest }: ActionServiceProperties): Service {
+	const handlerMap = new Map<string, ActionMiddleware>(handlers.map((handler) => [handler.type, handler.handler]));
+
+	const upgrade = realtimeUpgrade({
+		onMessage(data, con, methods) {
+			const action = typeof data === 'string' ? JSON.parse(data) : data;
+			if (isAction(action)) {
+				const handler = handlerMap.get(action.type) || defaultHandler;
+				if (handler) {
+					handler(action, con, methods);
+				}
+			}
+		},
+		...rest
+	});
+
+	return {
+		upgrade: {
+			upgrade
+		}
+	};
+}

--- a/src/core/services/chat.service.ts
+++ b/src/core/services/chat.service.ts
@@ -1,47 +1,29 @@
 import { Service } from '../app';
-import { websocket } from '../upgrades/websocket.upgrade';
-import { log } from '../log';
-import WebSocket from 'ws';
+import { realtimeService, RealtimeServiceProperties } from '../upgrades/realtime.upgrade';
+import { Guard } from '../interface';
 
-export interface ChatServiceProperties {}
-
-class User {
-	constructor(readonly id: string, readonly client: WebSocket) {}
+export interface ChatServiceProperties extends RealtimeServiceProperties {
+	guards?: Guard[];
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export function chatService(_props: ChatServiceProperties): Service {
-	const users: User[] = [];
-	const upgrade = websocket({
-		onClose(socketId, code, reason) {
-			log.debug(`{${socketId}} connection closed (${code}).${reason ? ` Reason: ${reason}` : ''}`);
-			const index = users.findIndex((user) => user.id === socketId);
-			if (index >= 0) {
-				users.splice(index, 1);
-			} else {
-				log.warn(`Unregistered user ${socketId} closed connection!`);
-			}
-		},
-		onConnection(client, socketId) {
-			log.debug(`{${socketId}} connected`);
-			const user = new User(socketId, client);
-			users.push(user);
-		},
-		onError(socketId, err) {
-			log.debug(`{${socketId}} errored. ${err && err.message}`);
-		},
-		onMessage(socketId, data) {
-			log.debug(`{${socketId}} says: ${data}`);
-			for (let user of users) {
-				if (user.id !== socketId) {
-					user.client.send(data);
-				}
-			}
+export const echoMessage: RealtimeServiceProperties['onMessage'] = (data, con, connections) => {
+	const socketId = con.id;
+	for (let target of connections) {
+		if (target.id !== socketId) {
+			target.client.send(data);
 		}
-	});
+	}
+};
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function chatService(props: ChatServiceProperties): Service {
 	return {
 		upgrade: {
-			upgrade
+			guards: props.guards ?? [],
+			upgrade: realtimeService({
+				onMessage: echoMessage,
+				...props
+			})
 		}
 	};
 }

--- a/src/core/services/chat.service.ts
+++ b/src/core/services/chat.service.ts
@@ -1,14 +1,14 @@
 import { Service } from '../app';
-import { realtimeService, RealtimeServiceProperties } from '../upgrades/realtime.upgrade';
+import { realtimeUpgrade, RealtimeUpgradeProperties } from '../upgrades/realtime.upgrade';
 import { Guard } from '../interface';
 
-export interface ChatServiceProperties extends RealtimeServiceProperties {
+export interface ChatServiceProperties extends RealtimeUpgradeProperties {
 	guards?: Guard[];
 }
 
-export const echoMessage: RealtimeServiceProperties['onMessage'] = (data, con, connections) => {
+export const echoMessage: RealtimeUpgradeProperties['onMessage'] = (data, con, { getAll }) => {
 	const socketId = con.id;
-	for (let target of connections) {
+	for (let target of getAll()) {
 		if (target.id !== socketId) {
 			target.client.send(data);
 		}
@@ -20,7 +20,7 @@ export function chatService(props: ChatServiceProperties): Service {
 	return {
 		upgrade: {
 			guards: props.guards ?? [],
-			upgrade: realtimeService({
+			upgrade: realtimeUpgrade({
 				onMessage: echoMessage,
 				...props
 			})

--- a/src/core/upgrades/proxy.upgrade.ts
+++ b/src/core/upgrades/proxy.upgrade.ts
@@ -7,6 +7,9 @@ export interface ProxyProperties {
 	proxy: Server;
 }
 
+/**
+ * This connects a local websocket to a proxied websocket
+ */
 export const proxyUpgrade: UpgradeMiddlewareFactory<ProxyProperties> = ({ baseUrl, proxy }) => {
 	return (request, socket, head) => {
 		log.debug(`Upgrade request for proxied "${baseUrl}"`);

--- a/src/core/upgrades/realtime.upgrade.spec.ts
+++ b/src/core/upgrades/realtime.upgrade.spec.ts
@@ -1,0 +1,203 @@
+/// <reference types="intern" />
+import { assert } from 'chai';
+import { before, describe, it } from 'intern/lib/interfaces/bdd';
+import { mockLog } from '../../_support/mocks/mockLog';
+import WebSocket = require('ws');
+
+import { describeSuite } from '../../_support/bdd';
+import { setupMocks, setupSinon } from '../../_support/mocks';
+
+describeSuite(__filename, () => {
+	const sinon = setupSinon();
+	const websocketUpgrader = sinon.stub();
+	const mockWebSocketUpgrade = sinon.stub().returns(websocketUpgrader);
+	const socketId = 'socketId';
+	const logMock = mockLog();
+	let realtimeUpgrade: typeof import('./realtime.upgrade').realtimeUpgrade;
+
+	setupMocks({
+		'../upgrades/websocket.upgrade': {
+			websocket: mockWebSocketUpgrade
+		},
+		'../log': {
+			log: logMock
+		}
+	});
+
+	before(() => {
+		realtimeUpgrade = require('./realtime.upgrade').realtimeUpgrade;
+	});
+
+	function createMockClient(): WebSocket {
+		return {
+			send: sinon.stub()
+		} as any;
+	}
+
+	function addConnection(id = socketId, client = createMockClient()) {
+		const { onConnection } = mockWebSocketUpgrade.lastCall.args[0];
+		assert.isFunction(onConnection);
+
+		onConnection(client, id);
+		return client;
+	}
+
+	describe('realtimeUpgrade', () => {
+		it('calls onInit on creation and passes methods', () => {
+			const onInit = sinon.stub();
+			const upgrader = realtimeUpgrade({
+				onInit
+			});
+
+			assert.strictEqual(upgrader, websocketUpgrader);
+			assert.strictEqual(onInit.callCount, 1);
+
+			const [methods] = onInit.lastCall.args;
+			assert.isDefined(methods);
+			assert.strictEqual(methods.getSize(), 0);
+			assert.deepEqual(Array.from(methods.getAll()), []);
+			assert.isUndefined(methods.get('socketId'));
+		});
+
+		it('works with only required properties', () => {
+			realtimeUpgrade({});
+
+			assert.strictEqual(mockWebSocketUpgrade.callCount, 1);
+			addConnection();
+
+			const { onClose, onError, onMessage } = mockWebSocketUpgrade.lastCall.args[0];
+			onMessage(socketId, {});
+			onError(socketId, new Error());
+			onClose(socketId, 42, 'reason');
+		});
+
+		describe('onConnection', () => {
+			it('adds a new connection', () => {
+				const onConnect = sinon.stub();
+				realtimeUpgrade({
+					onConnect
+				});
+
+				assert.strictEqual(mockWebSocketUpgrade.callCount, 1);
+				addConnection();
+
+				assert.strictEqual(onConnect.callCount, 1);
+				const [con, methods] = onConnect.lastCall.args;
+				assert.strictEqual(con.id, socketId);
+				assert.strictEqual(methods.get(socketId), con);
+			});
+		});
+
+		describe('onClose', () => {
+			const code = 42;
+			const reason = 'reason';
+
+			it('deletes a connection', () => {
+				const onDisconnect = sinon.stub();
+				realtimeUpgrade({
+					onDisconnect
+				});
+				addConnection();
+
+				assert.strictEqual(mockWebSocketUpgrade.callCount, 1);
+				const { onClose } = mockWebSocketUpgrade.lastCall.args[0];
+				assert.isFunction(onClose);
+
+				onClose(socketId, code, reason);
+				assert.strictEqual(onDisconnect.callCount, 1);
+				const [con, methods] = onDisconnect.lastCall.args;
+				assert.strictEqual(con.id, socketId);
+				assert.isUndefined(methods.get(socketId));
+			});
+
+			it('warns if there is no matching connection', () => {
+				const onDisconnect = sinon.stub();
+				realtimeUpgrade({
+					onDisconnect
+				});
+
+				assert.strictEqual(mockWebSocketUpgrade.callCount, 1);
+				const { onClose } = mockWebSocketUpgrade.lastCall.args[0];
+				assert.isFunction(onClose);
+
+				onClose(socketId, code, reason);
+				assert.strictEqual(onDisconnect.callCount, 0);
+				assert.strictEqual(logMock.warn.callCount, 1);
+			});
+		});
+
+		describe('onError', () => {
+			it('passes socketId when no matching connection', () => {
+				const err = new Error();
+				const onError = sinon.stub();
+				realtimeUpgrade({
+					onError
+				});
+
+				assert.strictEqual(mockWebSocketUpgrade.callCount, 1);
+				const { onError: internalOnError } = mockWebSocketUpgrade.lastCall.args[0];
+				assert.isFunction(internalOnError);
+
+				internalOnError(socketId, err);
+				assert.strictEqual(onError.callCount, 1);
+				assert.deepEqual(onError.lastCall.args, [err, socketId]);
+			});
+
+			it('passes the connection to onError', () => {
+				const err = new Error();
+				const onError = sinon.stub();
+				realtimeUpgrade({
+					onError
+				});
+				addConnection();
+
+				assert.strictEqual(mockWebSocketUpgrade.callCount, 1);
+				const { onError: internalOnError } = mockWebSocketUpgrade.lastCall.args[0];
+				assert.isFunction(internalOnError);
+
+				internalOnError(socketId, err);
+				assert.strictEqual(onError.callCount, 1);
+				const [error, con] = onError.lastCall.args;
+				assert.strictEqual(error, err);
+				assert.strictEqual(con.id, socketId);
+			});
+		});
+
+		describe('onMessage', () => {
+			const data = {};
+
+			it('does nothing if there is no matching connection', () => {
+				const onMessage = sinon.stub();
+				realtimeUpgrade({
+					onMessage
+				});
+
+				assert.strictEqual(mockWebSocketUpgrade.callCount, 1);
+				const { onMessage: internalOnMessage } = mockWebSocketUpgrade.lastCall.args[0];
+				assert.isFunction(internalOnMessage);
+
+				internalOnMessage(socketId, data);
+				assert.strictEqual(onMessage.callCount, 0);
+			});
+
+			it('handles the message', () => {
+				const onMessage = sinon.stub();
+				realtimeUpgrade({
+					onMessage
+				});
+
+				assert.strictEqual(mockWebSocketUpgrade.callCount, 1);
+				const { onMessage: internalOnMessage } = mockWebSocketUpgrade.lastCall.args[0];
+				assert.isFunction(internalOnMessage);
+				addConnection();
+
+				internalOnMessage(socketId, data);
+				assert.strictEqual(onMessage.callCount, 1);
+				const [message, con, methods] = onMessage.lastCall.args;
+				assert.strictEqual(message, data);
+				assert.strictEqual(con.id, socketId);
+				assert.strictEqual(methods.get(socketId), con);
+			});
+		});
+	});
+});

--- a/src/core/upgrades/realtime.upgrade.ts
+++ b/src/core/upgrades/realtime.upgrade.ts
@@ -1,0 +1,55 @@
+import WebSocket = require('ws');
+import { UpgradeMiddlewareFactory } from '../interface';
+import { log } from '../log';
+import { websocket } from './websocket.upgrade';
+
+export interface RealtimeServiceProperties {
+	onConnect?: (connection: Connection) => void;
+	onDisconnect?: (connection: Connection) => void;
+	onError?: (error: Error, connection: Connection | string) => void;
+	onMessage?: (data: any, connection: Connection, connections: Iterable<Connection>) => void;
+}
+
+export class Connection {
+	constructor(readonly id: string, readonly client: WebSocket) {}
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export const realtimeService: UpgradeMiddlewareFactory<RealtimeServiceProperties> = ({
+	onConnect,
+	onDisconnect,
+	onError,
+	onMessage
+} = {}) => {
+	const connections: Map<string, Connection> = new Map();
+
+	return websocket({
+		onClose(socketId, code, reason) {
+			log.debug(`{${socketId}} connection closed (${code}).${reason ? ` Reason: ${reason}` : ''}`);
+			const con = connections.get(socketId);
+
+			if (con) {
+				connections.delete(socketId);
+				onDisconnect && onDisconnect(con);
+			} else {
+				log.warn(`Unregistered user ${socketId} closed connection!`);
+			}
+		},
+		onConnection(client, socketId) {
+			log.debug(`{${socketId}} connected`);
+			const con = new Connection(socketId, client);
+			connections.set(con.id, con);
+			onConnect && onConnect(con);
+		},
+		onError(socketId, err) {
+			log.debug(`{${socketId}} errored. ${err && err.message}`);
+			const con = connections.get(socketId);
+			onError && onError(err, con || socketId);
+		},
+		onMessage(socketId, data) {
+			log.debug(`{${socketId}} says: ${data}`);
+			const con = connections.get(socketId);
+			con && onMessage(data, con, connections.values());
+		}
+	});
+};

--- a/src/core/upgrades/realtime.upgrade.ts
+++ b/src/core/upgrades/realtime.upgrade.ts
@@ -20,7 +20,7 @@ export const realtimeService: UpgradeMiddlewareFactory<RealtimeServiceProperties
 	onDisconnect,
 	onError,
 	onMessage
-} = {}) => {
+}) => {
 	const connections: Map<string, Connection> = new Map();
 
 	return websocket({
@@ -48,8 +48,10 @@ export const realtimeService: UpgradeMiddlewareFactory<RealtimeServiceProperties
 		},
 		onMessage(socketId, data) {
 			log.debug(`{${socketId}} says: ${data}`);
-			const con = connections.get(socketId);
-			con && onMessage(data, con, connections.values());
+			if (onMessage) {
+				const con = connections.get(socketId);
+				con && onMessage(data, con, connections.values());
+			}
 		}
 	});
 };

--- a/src/core/upgrades/upgrade.spec.ts
+++ b/src/core/upgrades/upgrade.spec.ts
@@ -1,0 +1,114 @@
+/// <reference types="intern" />
+import { describe, it } from 'intern/lib/interfaces/bdd';
+import { assert } from 'chai';
+
+import { describeSuite } from '../../_support/bdd';
+import { setupSinon } from '../../_support/mocks';
+import { multiupgrade, upgrade } from './upgrade';
+import { IncomingMessage } from 'http';
+import { Socket } from 'net';
+import { eventuallyRejects } from '../../_support/assertions';
+
+describeSuite(__filename, () => {
+	const sinon = setupSinon();
+	const request = {} as IncomingMessage;
+	const socket = {} as Socket;
+	const head = {} as Buffer;
+
+	describe('multiupgrade', () => {
+		it('upgrades descriptors', async () => {
+			const upgrades = [
+				{
+					guards: [() => true, () => Promise.resolve(false)],
+					upgrade: sinon.stub()
+				},
+				{
+					upgrade: sinon.stub()
+				}
+			];
+			const upgrade = multiupgrade({
+				upgrades
+			});
+
+			assert.isFunction(upgrade);
+			await upgrade(request, socket, head);
+			assert.isFalse(upgrades[0].upgrade.called);
+			assert.isTrue(upgrades[1].upgrade.called);
+		});
+
+		it('throws a HttpError when an upgrade is not available', () => {
+			const upgrader = multiupgrade({ upgrades: [] });
+
+			return eventuallyRejects(Promise.resolve(upgrader(request, socket, head)));
+		});
+	});
+
+	describe('upgrade', () => {
+		describe('test', () => {
+			it('returns true with zero guards', async () => {
+				const upgrader = upgrade({
+					guards: [],
+					upgrade: sinon.stub()
+				});
+
+				assert.isTrue(await upgrader.test(request));
+			});
+
+			it('returns true with all true guards', async () => {
+				const upgrader = upgrade({
+					guards: [() => true, () => true],
+					upgrade: sinon.stub()
+				});
+
+				assert.isTrue(await upgrader.test(request));
+			});
+
+			it('returns false with one false guard', async () => {
+				const upgrader = upgrade({
+					guards: [() => true, () => false],
+					upgrade: sinon.stub()
+				});
+
+				assert.isFalse(await upgrader.test(request));
+			});
+
+			it('returns true with all eventually true guards', async () => {
+				const upgrader = upgrade({
+					guards: [() => true, () => Promise.resolve(true)],
+					upgrade: sinon.stub()
+				});
+
+				assert.isTrue(await upgrader.test(request));
+			});
+
+			it('returns false with one eventually false guard', async () => {
+				const upgrader = upgrade({
+					guards: [() => true, () => Promise.resolve(false)],
+					upgrade: sinon.stub()
+				});
+
+				assert.isFalse(await upgrader.test(request));
+			});
+		});
+
+		describe('run', () => {
+			it('multiupgrades an array', async () => {
+				const mocks = [sinon.stub(), sinon.stub()];
+				const upgrader = upgrade({
+					upgrade: [{ guards: [() => false], upgrade: mocks[0] }, { upgrade: mocks[1] }]
+				});
+
+				await upgrader.run(request, socket, head);
+
+				assert.isFalse(mocks[0].called);
+				assert.isTrue(mocks[1].called);
+			});
+
+			it('passes through an upgrade', () => {
+				const mock = sinon.stub();
+				const upgrader = upgrade({ upgrade: mock });
+				assert.strictEqual(upgrader.run, mock);
+			});
+		});
+	});
+});

--- a/src/core/upgrades/upgrade.ts
+++ b/src/core/upgrades/upgrade.ts
@@ -29,7 +29,12 @@ export const upgrade: UpgradeFactory = ({ guards = [], upgrade }) => {
 	const run = Array.isArray(upgrade) ? multiupgrade({ upgrades: upgrade }) : upgrade;
 
 	async function test(request: IncomingMessage) {
-		return guards.every((guard) => guard(request));
+		for (let guard of guards) {
+			if (!(await guard(request))) {
+				return false;
+			}
+		}
+		return true;
 	}
 
 	return {

--- a/src/core/upgrades/websocket.upgrade.spec.ts
+++ b/src/core/upgrades/websocket.upgrade.spec.ts
@@ -1,0 +1,151 @@
+/// <reference types="intern" />
+import { describe, before, it } from 'intern/lib/interfaces/bdd';
+import { assert } from 'chai';
+import { describeSuite } from '../../_support/bdd';
+import { setupMocks, setupSinon } from '../../_support/mocks';
+import { IncomingMessage } from 'http';
+import { Socket } from 'net';
+import { WebSocketProperties } from './websocket.upgrade';
+
+describeSuite(__filename, () => {
+	let websocketUpgrade: typeof import('./websocket.upgrade').websocket;
+	const sinon = setupSinon();
+	const handleUpgradeMock = sinon.stub();
+	const mockServer = sinon.stub().returns({
+		handleUpgrade: handleUpgradeMock
+	});
+
+	setupMocks({
+		ws: {
+			Server: mockServer
+		}
+	});
+
+	before(() => {
+		websocketUpgrade = require('./websocket.upgrade').websocket;
+	});
+
+	it('adds a ws property to the upgrader', () => {
+		const upgrade = websocketUpgrade({});
+		assert.isDefined((upgrade as any).ws);
+		assert.deepEqual((upgrade as any).ws, { handleUpgrade: handleUpgradeMock });
+	});
+
+	describe('upgrader', () => {
+		const request = {} as IncomingMessage;
+		const socket = {} as Socket;
+		const head = {} as Buffer;
+		const client = {
+			on: sinon.stub()
+		};
+
+		function assertUpgrader(props: WebSocketProperties) {
+			const upgrader = websocketUpgrade(props);
+			const promise = upgrader(request, socket, head);
+
+			assert.strictEqual(handleUpgradeMock.callCount, 1);
+			assert.deepEqual(handleUpgradeMock.lastCall.args.slice(0, 3), [request, socket, head]);
+
+			const cb = handleUpgradeMock.lastCall.args[3];
+			cb(client);
+
+			return promise;
+		}
+
+		it('upgrades with minimal properties', async () => {
+			const promise = assertUpgrader({});
+
+			assert.strictEqual(client.on.callCount, 0);
+
+			return promise;
+		});
+
+		it('attaches listeners', () => {
+			const props = {
+				onMessage: sinon.stub(),
+				onClose: sinon.stub(),
+				onError: sinon.stub()
+			};
+			const promise = assertUpgrader(props);
+
+			assert.strictEqual(client.on.callCount, 3);
+
+			return promise;
+		});
+
+		it('calls onConnection', () => {
+			const props = {
+				onConnection: sinon.stub()
+			};
+			const promise = assertUpgrader(props);
+
+			assert.strictEqual(props.onConnection.callCount, 1);
+			assert.strictEqual(props.onConnection.lastCall.args[0], client);
+			assert.typeOf(props.onConnection.lastCall.args[1], 'string');
+			assert.strictEqual(props.onConnection.lastCall.args[2], request);
+
+			return promise;
+		});
+
+		it('calls onMessage', () => {
+			const props = {
+				onMessage: sinon.stub()
+			};
+			const data = {};
+			const promise = assertUpgrader(props);
+
+			assert.strictEqual(client.on.callCount, 1);
+			assert.strictEqual(client.on.lastCall.args[0], 'message');
+
+			const cb = client.on.lastCall.args[1];
+			cb(data);
+
+			assert.strictEqual(props.onMessage.callCount, 1);
+			assert.typeOf(props.onMessage.lastCall.args[0], 'string');
+			assert.strictEqual(props.onMessage.lastCall.args[1], data);
+
+			return promise;
+		});
+
+		it('calls onClose', () => {
+			const props = {
+				onClose: sinon.stub()
+			};
+			const code = 42;
+			const reason = 'answer found';
+			const promise = assertUpgrader(props);
+
+			assert.strictEqual(client.on.callCount, 1);
+			assert.strictEqual(client.on.lastCall.args[0], 'close');
+
+			const cb = client.on.lastCall.args[1];
+			cb(code, reason);
+
+			assert.strictEqual(props.onClose.callCount, 1);
+			assert.typeOf(props.onClose.lastCall.args[0], 'string');
+			assert.deepEqual(props.onClose.lastCall.args.slice(1), [code, reason]);
+
+			return promise;
+		});
+
+		it('calls onError', () => {
+			const props = {
+				onError: sinon.stub()
+			};
+			const error = new Error();
+			const promise = assertUpgrader(props);
+
+			assert.strictEqual(client.on.callCount, 1);
+			assert.strictEqual(client.on.lastCall.args[0], 'error');
+
+			const cb = client.on.lastCall.args[1];
+			cb(error);
+
+			assert.strictEqual(props.onError.callCount, 1);
+			assert.typeOf(props.onError.lastCall.args[0], 'string');
+			assert.deepEqual(props.onError.lastCall.args[1], error);
+
+			return promise;
+		});
+	});
+});

--- a/src/core/upgrades/websocket.upgrade.ts
+++ b/src/core/upgrades/websocket.upgrade.ts
@@ -10,6 +10,10 @@ export interface WebSocketProperties {
 	onError?(socketId: string, error: Error): void;
 }
 
+/**
+ * This provides a very basic implementation of the WebSocket upgrade process needed
+ * to establish a WebSocket connection.
+ */
 export const websocket: UpgradeMiddlewareFactory<WebSocketProperties> = ({
 	onClose,
 	onConnection,
@@ -23,7 +27,7 @@ export const websocket: UpgradeMiddlewareFactory<WebSocketProperties> = ({
 			const socketId = uuid();
 
 			ws.handleUpgrade(request, socket, head, (client) => {
-				onConnection && onConnection(client, socketId, request);
+				onConnection?.(client, socketId, request);
 				onMessage && client.on('message', (data) => onMessage(socketId, data));
 				onClose && client.on('close', (code, reason) => onClose(socketId, code, reason));
 				onError && client.on('error', (err) => onError(socketId, err));


### PR DESCRIPTION
Adds a `realtime.upgrade` that manages a list of connections linked to a uuid. This simplifies tracking roles and connections.